### PR TITLE
テストケースが1件だったときの条件分岐を追加

### DIFF
--- a/progressManagement.vbs
+++ b/progressManagement.vbs
@@ -296,7 +296,11 @@ End Function
 
 Function findArea(ByVal rng As Range) As Range
     rng.Select
-    Selection.End(xlToRight).Select
+    
+    'ケースが1件のみかチェック
+    If Cells(rng.Row, rng.Column + 1).Value <> "" Then
+        Selection.End(xlToRight).Select
+    End If
     Set endCellAdress = Selection.End(xlDown)
        
     Set findArea = Range(rng, endCellAdress)


### PR DESCRIPTION
#3 対応
テストケースNo1のひとつ右隣のセルの値が空文字のとき、テストケースNo2以降はないと判断する条件式を追加。